### PR TITLE
[Enhancement] Refactor addGameObject in Scene.ts

### DIFF
--- a/src/GameObject.ts
+++ b/src/GameObject.ts
@@ -40,10 +40,8 @@ class GameObject {
 	 * collision body.
 	 */
 	syncWithRigidBody() {
-		if (this.rapierRigidBody) {
-			this.threeJSGroup.position.copy(this.rapierRigidBody.translation());
-			this.threeJSGroup.quaternion.copy(this.rapierRigidBody.rotation());
-		}
+		this.threeJSGroup.position.copy(this.rapierRigidBody.translation());
+		this.threeJSGroup.quaternion.copy(this.rapierRigidBody.rotation());
 	}
 
 	/**

--- a/src/GameObject.ts
+++ b/src/GameObject.ts
@@ -11,10 +11,12 @@ import type { RigidBodyData } from "./types";
  * copied hella code from there.
  */
 class GameObject {
-	scene: Scene | null;
+	scene: Scene;
 	threeJSGroup: THREE.Mesh;
 	rigidBodyData: RigidBodyData;
-	rapierRigidBody: RAPIER.RigidBody | null;
+	// Used definite assignment operator here because logic is hidden away in
+	// addGameObjectToScene.
+	rapierRigidBody!: RAPIER.RigidBody;
 
 	/**
 	 * Creates a new GameObject instance.
@@ -30,8 +32,7 @@ class GameObject {
 		this.scene = scene;
 		this.threeJSGroup = threeJSGroup;
 		this.rigidBodyData = rigidBodyData;
-		this.rapierRigidBody = null;
-		this.scene.addGameObject(this); // why do this??
+		addGameObjectToScene(this, scene);
 	}
 
 	/**
@@ -52,6 +53,28 @@ class GameObject {
 	getScene() {
 		return this.scene;
 	}
+}
+
+/**
+ * Adds a given game object to a given scene.
+ * Setup the gameObject.rapierRigidBody property.
+ * @param gameObject - The game object to add.
+ * @param scene - The scene to add the object to
+ */
+function addGameObjectToScene(gameObject: GameObject, scene: Scene): void {
+	if (scene.gameObjects.some((g) => g === gameObject)) {
+		throw new Error("GameObject already exists in the scene.");
+	}
+	scene.gameObjects.push(gameObject);
+	scene.threeJSScene.add(gameObject.threeJSGroup);
+	const rapierRigidBody = scene.rapierWorld.createRigidBody(
+		gameObject.rigidBodyData.rigidBodyDesc,
+	);
+	scene.rapierWorld.createCollider(
+		gameObject.rigidBodyData.colliderDesc,
+		rapierRigidBody,
+	);
+	gameObject.rapierRigidBody = rapierRigidBody;
 }
 
 export default GameObject;

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -78,8 +78,8 @@ class Scene {
 		this.rapierWorld.step();
 		this.gameObjects.forEach((gameObject) => {
 			gameObject.syncWithRigidBody();
-			gameObject.rapierRigidBody?.resetForces(false);
-			gameObject.rapierRigidBody?.resetTorques(false);
+			gameObject.rapierRigidBody.resetForces(false);
+			gameObject.rapierRigidBody.resetTorques(false);
 		});
 	}
 

--- a/src/Scene.ts
+++ b/src/Scene.ts
@@ -84,39 +84,6 @@ class Scene {
 	}
 
 	/**
-	 * Adds a game object to the scene.
-	 * Creates a rigid body and collider for the game object.
-	 * @param gameObject - The game object to add.
-	 */
-	addGameObject(gameObject: GameObject) {
-		if (!this.gameObjects.some((g) => g === gameObject)) {
-			gameObject.scene = this;
-			this.gameObjects.push(gameObject);
-			this.threeJSScene.add(gameObject.threeJSGroup);
-			gameObject.rapierRigidBody = this.rapierWorld.createRigidBody(
-				gameObject.rigidBodyData.rigidBodyDesc,
-			);
-			this.rapierWorld.createCollider(
-				gameObject.rigidBodyData.colliderDesc,
-				gameObject.rapierRigidBody,
-			);
-		}
-	}
-
-	/**
-	 * Removes a game object from the scene.
-	 * @param gameObject - The game object to remove.
-	 */
-	removeGameObject(gameObject: GameObject) {
-		if (this.gameObjects.some((g) => g === gameObject)) {
-			// gameObject is indeed a child of this scene
-			this.gameObjects = this.gameObjects.filter((g) => g !== gameObject);
-			gameObject.scene = null;
-			this.threeJSScene.remove(gameObject.threeJSGroup);
-		}
-	}
-
-	/**
 	 * Adds the physics rendering lines to the scene if they are not already present.
 	 */
 	showPhysics() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,12 +51,12 @@ async function game() {
 			.setAngularDamping(0.3),
 	};
 	const sphereObject = new GameObject(scene, sphereMesh, sphereCollider);
-	sphereObject.rapierRigidBody?.setTranslation({ x: 0, y: 2, z: 1 }, false);
+	sphereObject.rapierRigidBody.setTranslation({ x: 0, y: 2, z: 1 }, false);
 
 	// Player
 	const playerMesh = await loadModel("./assets/models/raceFuture.glb");
 	const player: Player = new Player(scene, playerMesh as THREE.Mesh);
-	player.rapierRigidBody?.setTranslation({ x: 0, y: 3, z: 10 }, false);
+	player.rapierRigidBody.setTranslation({ x: 0, y: 3, z: 10 }, false);
 
 	// Input
 	const input = new KeyboardHandler();

--- a/src/util/Player.ts
+++ b/src/util/Player.ts
@@ -44,7 +44,7 @@ class Player extends GameObject {
 	 */
 	getRelativeVector(inputVec: Vec3) {
 		const vec: THREE.Vector3 = new THREE.Vector3().copy(inputVec);
-		vec.applyQuaternion(this.rapierRigidBody?.rotation() as THREE.Quaternion);
+		vec.applyQuaternion(this.rapierRigidBody.rotation() as THREE.Quaternion);
 		return vec;
 	}
 
@@ -78,9 +78,6 @@ class Player extends GameObject {
 	 * @throws Error if the game object does not have a rapierRigidBody.
 	 */
 	getPosition() {
-		if (!this.rapierRigidBody) {
-			throw new Error("Game object does not have rapierRigidBody");
-		}
 		return new THREE.Vector3().copy(this.rapierRigidBody.translation());
 	}
 
@@ -90,9 +87,6 @@ class Player extends GameObject {
 	 * @throws Error if the game object does not have a rapierRigidBody.
 	 */
 	getVelocity() {
-		if (!this.rapierRigidBody) {
-			throw new Error("Game object does not have rapierRigidBody");
-		}
 		return new THREE.Vector3().copy(this.rapierRigidBody.linvel());
 	}
 
@@ -102,9 +96,6 @@ class Player extends GameObject {
 	 * @throws Error if the game object does not have a rapierRigidBody.
 	 */
 	control(k: KeyboardHandler) {
-		if (!this.rapierRigidBody) {
-			throw new Error("Game object does not have rapierRigidBody");
-		}
 		const input: carInput = {
 			yaw: Number(k.isKeyDown("a")) - Number(k.isKeyDown("d")),
 			roll: Number(k.isKeyDown("q")) - Number(k.isKeyDown("e")),
@@ -149,12 +140,6 @@ class Player extends GameObject {
 	 * @throws Error if the game object is not in a scene or does not have a rapierRigidBody.
 	 */
 	rayCastToGround(): RAPIER.RayColliderHit {
-		if (!this.scene) {
-			throw new Error("Game object is not in scene");
-		}
-		if (!this.rapierRigidBody) {
-			throw new Error("Game object does not have rapierRigidBody");
-		}
 		const rapierWorld: RAPIER.World = this.scene.rapierWorld;
 		const currentPosition: THREE.Vector3 = this.getPosition();
 

--- a/src/util/Player.ts
+++ b/src/util/Player.ts
@@ -108,7 +108,6 @@ class Player extends GameObject {
 			1.5 * input.yaw,
 		);
 
-		console.log(this.isOnGround());
 		if (!this.isOnGround()) {
 			torque.add(this.getForward().multiplyScalar(1.5 * input.roll));
 		}


### PR DESCRIPTION
Resolves #14 

I removed the methods `addGameObject` and `removeGameObject` from the `Scene` class. 

Then I added `addGameObjectToScene` as a helper function for the `GameObject` class.

This allows the `rapierRigidBody` property of the `GameObject` class to not have null type anymore.

```javascript
class GameObject {
	scene: Scene;
	threeJSGroup: THREE.Mesh;
	rigidBodyData: RigidBodyData;
	// Used definite assignment operator here because logic is hidden away in
	// addGameObjectToScene().
	rapierRigidBody!: RAPIER.RigidBody;
```
